### PR TITLE
Fix: Allow all hosts in Vite configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,8 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		allowedHosts: true
+	}
 });


### PR DESCRIPTION
Set `server.allowedHosts` to `true` in `vite.config.ts` to allow all hosts.

Fix Blocked request. This host ("【REDACTED】") is not allowed.
To allow this host, add "【REDACTED】" to `server.allowedHosts` in vite.config.js.
